### PR TITLE
Use import structure for pip-installed package

### DIFF
--- a/jwst/jwst_nircam_pupil.py
+++ b/jwst/jwst_nircam_pupil.py
@@ -4,12 +4,8 @@ import astropy.io.fits as pyfits
 import matplotlib.pyplot as plt
 import numpy as np
 
-import os
-import sys
-
-sys.path.append('/Users/jkammerer/Documents/Code/xara/xara')
-from core import create_discrete_model, symetrizes_model
-import kpi
+from xara.core import create_discrete_model, symetrizes_model
+from xara import kpi
 
 
 # =============================================================================

--- a/jwst/jwst_nircam_run.py
+++ b/jwst/jwst_nircam_run.py
@@ -1,14 +1,6 @@
 from __future__ import division
 
-import astropy.io.fits as pyfits
-import matplotlib.pyplot as plt
-import numpy as np
-
-import os
-import sys
-
-sys.path.append('/Users/jkammerer/Documents/Code/xara/xara')
-from calwebb_kpi3 import KPI3Pipeline
+from xara.calwebb_kpi3 import KPI3Pipeline
 
 
 # =============================================================================

--- a/jwst/jwst_niriss_pupil.py
+++ b/jwst/jwst_niriss_pupil.py
@@ -4,12 +4,8 @@ import astropy.io.fits as pyfits
 import matplotlib.pyplot as plt
 import numpy as np
 
-import os
-import sys
-
-sys.path.append('/Users/jkammerer/Documents/Code/xara/xara')
-from core import create_discrete_model, symetrizes_model
-import kpi
+from xara.core import create_discrete_model, symetrizes_model
+from xara import kpi
 
 
 # =============================================================================

--- a/jwst/jwst_niriss_run.py
+++ b/jwst/jwst_niriss_run.py
@@ -1,14 +1,6 @@
 from __future__ import division
 
-import astropy.io.fits as pyfits
-import matplotlib.pyplot as plt
-import numpy as np
-
-import os
-import sys
-
-sys.path.append('/Users/jkammerer/Documents/Code/xara/xara')
-from calwebb_kpi3 import KPI3Pipeline
+from xara.calwebb_kpi3 import KPI3Pipeline
 
 
 # =============================================================================

--- a/xara/calwebb_kpi3.py
+++ b/xara/calwebb_kpi3.py
@@ -11,15 +11,13 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 import os
-import sys
 
 import matplotlib.patheffects as PathEffects
 
 from scipy.ndimage import median_filter
 
-import core
-import kpi
-import kpo
+from . import core
+from . import kpo
 
 show_plots = False
 

--- a/xara/kpo.py
+++ b/xara/kpo.py
@@ -27,8 +27,8 @@ import astropy.io.fits as fits
 from astropy.time import Time
 import copy
 
-import core
-import kpi
+from . import core
+from . import kpi
 
 shift = np.fft.fftshift
 fft = np.fft.fft2


### PR DESCRIPTION
Hi Jens,

As discussed via email, this PR just updates the import structure to be compatible with a pip-installed xara. Local edits can still be used if xara was installed with `pip install -e </path/to/xara/>`.

Thank you!