### PR TITLE
Include pupil models even if not locally installed

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include README.rst
 include xara/*.txt
 include xara/bin/*
 include xara/*.fits.gz
+include jwst/*pupil.fits

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,12 @@ setup(name='xara',
           'numpy', 'scipy', 'matplotlib', 'astropy'
       ],
       scripts=["bin/ker_model_builder"],
-      data_files=[('config', ['config/discretizor.ui'])],
+      data_files=[
+          ('config', ['config/discretizor.ui']),
+          ("xara_jwst_pupils",
+              ["jwst/nircam_clear_pupil.fits",
+               "jwst/niriss_clear_pupil.fits",
+               "jwst/niriss_nrm_pupil.fits"])
+      ],
       include_package_data=True,
       zip_safe=False)

--- a/xara/calwebb_kpi3.py
+++ b/xara/calwebb_kpi3.py
@@ -10,6 +10,7 @@ import astropy.io.fits as pyfits
 import matplotlib.pyplot as plt
 import numpy as np
 
+import sys
 import os
 
 import matplotlib.patheffects as PathEffects
@@ -366,15 +367,17 @@ class recenter_frames():
 
             # Get pupil model path and filter effective wavelength and width.
             if (INSTRUME == 'NIRCAM'):
-                path = os.path.realpath(__file__)
-                temp = path.rfind('/')
-                fname = path[:temp]+'/../jwst/nircam_clear_pupil.fits'
+                fname = os.path.join(sys.prefix, "xara_jwst_pupils", 'nircam_clear_pupil.fits')
+                # path = os.path.realpath(__file__)
+                # temp = path.rfind('/')
+                # fname = path[:temp]+'/../jwst/nircam_clear_pupil.fits'
                 wave = wave_nircam[FILTER]*1e-6  # m
                 weff = weff_nircam[FILTER]*1e-6  # m
             elif (INSTRUME == 'NIRISS'):
-                path = os.path.realpath(__file__)
-                temp = path.rfind('/')
-                fname = path[:temp]+'/../jwst/niriss_clear_pupil.fits'
+                fname = os.path.join(sys.prefix, "xara_jwst_pupils", 'niriss_clear_pupil.fits')
+                # path = os.path.realpath(__file__)
+                # temp = path.rfind('/')
+                # fname = path[:temp]+'/../jwst/niriss_clear_pupil.fits'
                 wave = wave_niriss[FILTER]*1e-6  # m
                 weff = weff_niriss[FILTER]*1e-6  # m
 
@@ -791,15 +794,17 @@ class extract_kerphase():
 
         # Get pupil model path and filter effective wavelength and width.
         if (INSTRUME == 'NIRCAM'):
-            path = os.path.realpath(__file__)
-            temp = path.rfind('/')
-            fname = path[:temp]+'/../jwst/nircam_clear_pupil.fits'
+            fname = os.path.join(sys.prefix, "xara_jwst_pupils", 'nircam_clear_pupil.fits')
+            # path = os.path.realpath(__file__)
+            # temp = path.rfind('/')
+            # fname = path[:temp]+'/../jwst/nircam_clear_pupil.fits'
             wave = wave_nircam[FILTER]*1e-6  # m
             weff = weff_nircam[FILTER]*1e-6  # m
         elif (INSTRUME == 'NIRISS'):
-            path = os.path.realpath(__file__)
-            temp = path.rfind('/')
-            fname = path[:temp]+'/../jwst/niriss_clear_pupil.fits'
+            fname = os.path.join(sys.prefix, "xara_jwst_pupils", 'niriss_clear_pupil.fits')
+            # path = os.path.realpath(__file__)
+            # temp = path.rfind('/')
+            # fname = path[:temp]+'/../jwst/niriss_clear_pupil.fits'
             wave = wave_niriss[FILTER]*1e-6  # m
             weff = weff_niriss[FILTER]*1e-6  # m
 

--- a/xara/calwebb_kpi3.py
+++ b/xara/calwebb_kpi3.py
@@ -368,16 +368,18 @@ class recenter_frames():
             # Get pupil model path and filter effective wavelength and width.
             if (INSTRUME == 'NIRCAM'):
                 fname = os.path.join(sys.prefix, "xara_jwst_pupils", 'nircam_clear_pupil.fits')
-                # path = os.path.realpath(__file__)
-                # temp = path.rfind('/')
-                # fname = path[:temp]+'/../jwst/nircam_clear_pupil.fits'
+                if not os.path.exists(fname):
+                    path = os.path.realpath(__file__)
+                    temp = path.rfind('/')
+                    fname = path[:temp]+'/../jwst/nircam_clear_pupil.fits'
                 wave = wave_nircam[FILTER]*1e-6  # m
                 weff = weff_nircam[FILTER]*1e-6  # m
             elif (INSTRUME == 'NIRISS'):
                 fname = os.path.join(sys.prefix, "xara_jwst_pupils", 'niriss_clear_pupil.fits')
-                # path = os.path.realpath(__file__)
-                # temp = path.rfind('/')
-                # fname = path[:temp]+'/../jwst/niriss_clear_pupil.fits'
+                if not os.path.exists(fname):
+                    path = os.path.realpath(__file__)
+                    temp = path.rfind('/')
+                    fname = path[:temp]+'/../jwst/nircam_clear_pupil.fits'
                 wave = wave_niriss[FILTER]*1e-6  # m
                 weff = weff_niriss[FILTER]*1e-6  # m
 
@@ -795,16 +797,18 @@ class extract_kerphase():
         # Get pupil model path and filter effective wavelength and width.
         if (INSTRUME == 'NIRCAM'):
             fname = os.path.join(sys.prefix, "xara_jwst_pupils", 'nircam_clear_pupil.fits')
-            # path = os.path.realpath(__file__)
-            # temp = path.rfind('/')
-            # fname = path[:temp]+'/../jwst/nircam_clear_pupil.fits'
+            if not os.path.exists(fname):
+                path = os.path.realpath(__file__)
+                temp = path.rfind('/')
+                fname = path[:temp]+'/../jwst/nircam_clear_pupil.fits'
             wave = wave_nircam[FILTER]*1e-6  # m
             weff = weff_nircam[FILTER]*1e-6  # m
         elif (INSTRUME == 'NIRISS'):
             fname = os.path.join(sys.prefix, "xara_jwst_pupils", 'niriss_clear_pupil.fits')
-            # path = os.path.realpath(__file__)
-            # temp = path.rfind('/')
-            # fname = path[:temp]+'/../jwst/niriss_clear_pupil.fits'
+            if not os.path.exists(fname):
+                path = os.path.realpath(__file__)
+                temp = path.rfind('/')
+                fname = path[:temp]+'/../jwst/niriss_clear_pupil.fits'
             wave = wave_niriss[FILTER]*1e-6  # m
             weff = weff_niriss[FILTER]*1e-6  # m
 


### PR DESCRIPTION
This adds the pupil model fits files to the pip package distribution (in `setup.py` and `MANIFEST.in`) and ajusts the path accordingly when loading the data. There is a fallback to the previous code if the file was not found, to handle the case in which the repo is cloned and installed locally.