### PR TITLE
np.float -> float

### DIFF
--- a/xara/kpi.py
+++ b/xara/kpi.py
@@ -427,7 +427,7 @@ class KPI(object):
         # ------------------------------------
         tmp = hdulist['UV-PLANE'].data
         self.UVC = np.array([tmp['UUC'], tmp['VVC']]).T
-        self.RED = np.array(tmp['RED']).astype(np.float)
+        self.RED = np.array(tmp['RED']).astype(float)
 
         self.KPM = hdulist['KER-MAT'].data
         self.BLM = hdulist['BLM-MAT'].data

--- a/xara/kpo.py
+++ b/xara/kpo.py
@@ -603,7 +603,7 @@ class KPO():
 
             # KP-DATA HDU
             # -----------
-            kpd_hdu = fits.ImageHDU(self.KPDT[ii].astype(np.float64))
+            kpd_hdu = fits.ImageHDU(self.KPDT[ii].astype(float))
             kpd_hdu.header.add_comment("Kernel-phase data")
             kpd_hdu.header['EXTNAME'] = 'KP-DATA%d' % (ii+1,)
             kpd_hdu.header['TARGET'] = self.TARGET[ii]
@@ -635,7 +635,7 @@ class KPO():
 
         try:
             _ = self.kp_cov
-            kcv_hdu = fits.ImageHDU(self.kp_cov.astype(np.float64))
+            kcv_hdu = fits.ImageHDU(self.kp_cov.astype(float))
             kcv_hdu.header.add_comment(
                 "Kernel-phase covariance matrix")
             kcv_hdu.header['EXTNAME'] = 'KP-COV'


### PR DESCRIPTION
`np.float` is deprecated and causes a warning. Replacing with the built-in float fixes the issue.