### PR TITLE
Make integer-pixel recentering independent of sgmask

### DIFF
--- a/xara/core.py
+++ b/xara/core.py
@@ -591,7 +591,7 @@ def recenter(im0, mask=None, algo="BCEN", subpix=True, between=False,
 
     ysz, xsz = im0.shape
 
-    if (dxdy is None):
+    if dxdy is None:
         (x0, y0) = determine_origin(im0, mask=mask, algo=algo, verbose=verbose,
                                     mykpo=mykpo, m2pix=m2pix, bmax=bmax)
 
@@ -645,7 +645,7 @@ def recenter(im0, mask=None, algo="BCEN", subpix=True, between=False,
         offset = np.exp(1j*slope)
         dummy = np.real(shift(ifft(offset * fft(shift(im)))))
         im0 = dummy[oriy:oriy+ysz, orix:orix+xsz]
-    if (return_center == False):
+    if not return_center:
         return im0
     else:
         return im0, dx_temp, dy_temp

--- a/xara/core.py
+++ b/xara/core.py
@@ -570,6 +570,18 @@ def recenter(im0, mask=None, algo="BCEN", subpix=True, between=False,
     - subpix: sub-pixel recentering         (boolean, default=True)
     - between: center in between 4 pixels   (boolean, default=False)
     - verbose: display some additional info (boolean, default=True)
+    - return_center: return center coordinate in original image (boolean, default=False)
+    - dxdy: center coordinates to use, origin is found with `algo` if None (Tuple[float], default=None)
+    - mykpo: KPO object, used to determine origin with FPNM (xara.kpo.KPO, default=None)
+    - m2pix: Meter to pixel scaling parameter for FPNM (float, default=None)
+    - bmax: Max baseline (in m) for FPNM (float, default=None)
+
+    Returns:
+    -------
+    - img: The recentered image
+    - If `return_center` is True:
+      + dx_temp: x coordinate of the center in original image
+      + dy_temp: y coordinate of the center in original image
 
     Remarks:
     -------

--- a/xara/kpi.py
+++ b/xara/kpi.py
@@ -82,6 +82,7 @@ class KPI(object):
         - ndgt: (integer) number of digits when rounding x,y baselines
         - bmax: length of the max baseline kept in the model (in meters)
         - ID  : (string) give the KPI structure a human readable ID
+        - hexa: (bool) if True, masks out noisy baselines using a hexagonal shape
 
         Remarks:
         -------

--- a/xara/kpi.py
+++ b/xara/kpi.py
@@ -505,7 +505,7 @@ class KPI(object):
     # =========================================================================
 
     def plot_pupil_and_uv(self, xymax=4.0, figsize=(12, 6), plot_redun=False,
-                          cmap=cm.gray, ssize=12, lw=0, alpha=1.0, marker='s'):
+                          cmap=cm.rainbow, ssize=12, lw=0, alpha=1.0, marker='o'):
         '''Nice plot of the pupil sampling and matching uv plane.
 
         --------------------------------------------------------------------
@@ -515,11 +515,11 @@ class KPI(object):
         - xymax: radius of pupil plot in meters           (default=4.0)
         - figsize: matplotlib figure size                 (default=(12,6))
         - plot_redun: bool add the redundancy information (default=False)
-        - cmap: matplotlib colormap                       (default:cm.gray)
+        - cmap: matplotlib colormap                       (default:cm.rainbow)
         - ssize: symbol size                              (default=12)
         - lw:  line width for symbol outline              (default=0)
         - alpha: gamma (transparency)                     (default=1)
-        - maker: matplotlib marker for sub-aperture       (default='s')
+        - maker: matplotlib marker for sub-aperture       (default='o')
         - -------------------------------------------------------------------
         '''
 

--- a/xara/kpo.py
+++ b/xara/kpo.py
@@ -525,7 +525,7 @@ class KPO():
         self.KPDT.append(np.array(kpdata))
         self.DETPA.append(np.array(detpa).flatten())
         self.MJDATE.append(np.array(mjdate))
-        if recenter is True:
+        if recenter:
             return dx, dy
         else:
             return

--- a/xara/kpo.py
+++ b/xara/kpo.py
@@ -477,7 +477,7 @@ class KPO():
             self.sgmask = core.super_gauss(isz, isz, wrad)
 
         img = frame.copy()
-        if recenter is True:
+        if recenter:
             ysz, xsz = frame.shape
             (x0, y0) = core.determine_origin(img, mask=self.sgmask,
                                              algo=algo_cent, verbose=False,

--- a/xara/kpo.py
+++ b/xara/kpo.py
@@ -485,25 +485,19 @@ class KPO():
                                              bmax=bmax_cent)
             dy, dx = (y0-ysz/2), (x0-xsz/2)
 
+            img = np.roll(np.roll(img, -int(round(dx)), axis=1),
+                          -int(round(dy)), axis=0)
+            dx_temp = dx - int(round(dx))
+            dy_temp = dy - int(round(dy))
+
         if self.sgmask is not None:  # use apodization mask before extraction
-            if recenter is True:
-                # img *= np.roll(np.roll(self.sgmask, int(round(dx)), axis=1),
-                #                int(round(dy)), axis=0)
-                img = np.roll(np.roll(img, -int(round(dx)), axis=1),
-                              -int(round(dy)), axis=0)
-                img *= self.sgmask
-                dx_temp = dx-int(round(dx))
-                dy_temp = dy-int(round(dy))
-            else:
-                img *= self.sgmask
-                dx_temp = dx
-                dy_temp = dy
+            img *= self.sgmask
 
         # ----- complex visibility extraction -----
         temp = self.extract_cvis_from_img(img, m2pix, method)
 
         # ---- sub-pixel recentering correction -----
-        if recenter is True:
+        if recenter:
             uvc = self.kpi.UVC * self.M2PIX
             corr = np.exp(i2pi * uvc.dot(np.array([dx_temp, dy_temp])/float(ysz)))
             temp *= corr


### PR DESCRIPTION
In `extract_KPD_single_frame()`, the integer pixel recentering was performed only if `sgmask` was not done. This was an artifact from when the mask, and not the image, was shifted. Now that the image itself is shifted the recenter code can go with the block to determine the origin, and the mask application is now a single line.

This depends on changes in #15 so should probably be merged after.