### PR TITLE
Reapply old changes that got overwritten

### DIFF
--- a/xara/kpi.py
+++ b/xara/kpi.py
@@ -429,7 +429,7 @@ class KPI(object):
         # ------------------------------------
         tmp = hdulist['UV-PLANE'].data
         self.UVC = np.array([tmp['UUC'], tmp['VVC']]).T
-        self.RED = np.array(tmp['RED']).astype(np.float)
+        self.RED = np.array(tmp['RED']).astype(float)
 
         self.KPM = hdulist['KER-MAT'].data
         self.BLM = hdulist['BLM-MAT'].data

--- a/xara/kpi.py
+++ b/xara/kpi.py
@@ -42,7 +42,7 @@ from astropy.io import fits
 import pickle
 import gzip
 
-from .opticstools import opticstools as ot
+from .core import hexagon
 
 
 class KPI(object):
@@ -245,7 +245,7 @@ class KPI(object):
         if bmax is not None:
             if hexa:
                 flat_to_flat = 2.*6.5 # m, size is doubled in uv-plane
-                mask = ot.hexagon(1024, 512*2.*float(bmax)/flat_to_flat, interp_edge=False) # center is (512, 512)
+                mask = hexagon(1024, 512*2.*float(bmax)/flat_to_flat, interp_edge=False) # center is (512, 512)
                 uv_sampl = self.UVC.copy()   # copy previously identified baselines
                 # uvm = np.abs(self.UVC).max() # max baseline length
 

--- a/xara/kpo.py
+++ b/xara/kpo.py
@@ -966,7 +966,7 @@ class KPO():
         data2 = np.append(data, data) if sym else np.append(data, -data)
 
         ssz = ssize**2  # symbol size
-        dtitle = "Fourier map" if title is "" else title
+        dtitle = "Fourier map" if title == "" else title
 
         if not cbar:
             fig, ax = plt.subplots()


### PR DESCRIPTION
Some previous changes seem to have been overwritten by a rebase or merge from another branch. Namely:

- Importing the `hexagon()` function from `xara.core` instead of `opticstools`
- Using built-in `float` instead of `np.float` (which is now deprecated)

The first one caused an error when I tried to run from `develop` (because I don't have `opticstools` linked or copied in my `xara` dir. The second one causes a warning and will probably cause an error in future versions.

@kammerje let me know if anything needs to be updated or changed other than these two things (or if one of them should be reverted/put on hold).

Thanks!