### PR TITLE
Enable loading to and saving from KPFITS format

### DIFF
--- a/xara/__init__.py
+++ b/xara/__init__.py
@@ -70,10 +70,6 @@ __version__ = '.'.join(str(c) for c in version_info)
 (plt.rcParams)['image.interpolation'] = 'nearest'
 # -------------------------------------------------
 
-plt.ion()
-plt.show()
-
-
 # =========================================================================
 # =========================================================================
 def field_map_cbar(gmap, gstep, cmap=cm.viridis, fsize=5.2,

--- a/xara/core.py
+++ b/xara/core.py
@@ -382,7 +382,7 @@ def centroid(image, threshold=0, binarize=False):
 
 
 # =========================================================================
-def find_psf_center(img, verbose=True, nbit=10, visu=False, wmin=10.0):
+def find_psf_center(img, verbose=True, nbit=10, wmin=10.0):
     ''' Name of function self explanatory: locate the center of a PSF.
 
     ------------------------------------------------------------------
@@ -405,11 +405,6 @@ def find_psf_center(img, verbose=True, nbit=10, visu=False, wmin=10.0):
 
     i0 = float(nbit-1) / np.log(sx/wmin)
 
-    if visu:
-        plt.figure()
-        plt.ion()
-        plt.show()
-
     for it in range(nbit):
         sz = np.round(sx/2 * np.exp(-it/i0))
         x0 = np.max([int(0.5 + xc - sz), 0])
@@ -419,11 +414,6 @@ def find_psf_center(img, verbose=True, nbit=10, visu=False, wmin=10.0):
 
         mask = np.zeros_like(img)
         mask[y0:y1, x0:x1] = 1.0
-
-        if visu:
-            plt.clf()
-            plt.imshow((mfilt**0.2) * mask)
-            plt.pause(0.1)
 
         profx = (mfilt*mask*signal).sum(axis=0)
         profy = (mfilt*mask*signal).sum(axis=1)

--- a/xara/fitting.py
+++ b/xara/fitting.py
@@ -19,8 +19,6 @@ from numpy.random import rand, randn
 import matplotlib.pyplot as plt
 from scipy.ndimage import rotate
 
-plt.ion()
-
 # =========================================================================
 # =========================================================================
 def vertical_rim(gsz=256, gstep=15, height=100, rad=450, cont=1e-3,

--- a/xara/kpi.py
+++ b/xara/kpi.py
@@ -99,6 +99,7 @@ class KPI(object):
         improves the overall performance in the presence of noisy data.
         -------------------------------------------------------------------'''
 
+        # TODO: Would be nice if can apply bmax a-posteriori
         if fname is not None:
             print("Attempting to load file %s" % (fname,))
             if '.fits' in fname:
@@ -449,6 +450,7 @@ class KPI(object):
         self.BLEN = np.hypot(self.UVC[:, 0], self.UVC[:, 1])
 
         if ap_flag:
+            # TODO: Remove commented line
             self.TFM = np.diag(1./self.RED).dot(self.BLM[:, 1:])
             # self.TFM = np.dot(np.diag(1./self.RED), self.TFM)  # redundancy
 

--- a/xara/kpi.py
+++ b/xara/kpi.py
@@ -80,7 +80,9 @@ class KPI(object):
         Option:
         ------
         - ndgt: (integer) number of digits when rounding x,y baselines
-        - bmax: length of the max baseline kept in the model (in meters)
+        - bmax: length of the max baseline kept in the model (in meters).
+                For hexa=True, the longuest baseline will be longer than the input value.
+                This is a known bug. Adjust to lower values accordingly. 5.7 gives 6.3 for JWST.
         - ID  : (string) give the KPI structure a human readable ID
 
         Remarks:

--- a/xara/kpo.py
+++ b/xara/kpo.py
@@ -98,8 +98,9 @@ class KPO():
 
     def _get_kpo_kpfits(self, hdul: fits.HDUList):
         # TODO: Support KP sigma and cov
+        # TODO: Support multi-lambda (axis=1) in numpy, not sure xara does that yet?
         # TODO: Support MJDATE
-        self.KPDT.append(hdul['KP-DATA'].data[0])
+        self.KPDT.append(hdul['KP-DATA'].data[:, 0])
 
         self.PSCALE = hdul[0].header['PSCALE']
 
@@ -108,7 +109,8 @@ class KPO():
 
         self.DETPA.append(hdul['DETPA'].data)
         cvis_arr = hdul['CVIS-DATA'].data
-        self.CVIS = list(cvis_arr[:, 0, ...] + 1j * cvis_arr[:, 1, ...])
+        # TODO: Support multi-lambda (axis=2) in numpy, not sure xara does that yet?
+        self.CVIS.append(cvis_arr[0, :, 0] + 1j * cvis_arr[1, :, 0])
 
     def _get_kpo_legacy(self, hdul: fits.HDUList):
         # how many data sets are included?

--- a/xara/kpo.py
+++ b/xara/kpo.py
@@ -654,7 +654,7 @@ class KPO():
         kpdt_arr = np.concatenate(self.KPDT)
         if len(self.KPDT) > 1:
             warnings.warn(
-                "Saving all extracted frames and cubges in a single KPFITS file"
+                "Saving all extracted frames and cubes in a single KPFITS file"
                 " along the 'frame' dimension."
                 " Use separate KPO objects if you want something else.",
                 stacklevel=2,

--- a/xara/kpo.py
+++ b/xara/kpo.py
@@ -51,8 +51,8 @@ class KPO():
         set.
         ------------------------------------------------------------------- '''
 
-    # TODO: Using KPFITS as default would break backward compat... Could keep default but have warning for few releases? Or just keep legacy as default
-    def __init__(self, fname=None, array=None, ndgt=5, bmax=None, hexa=False, input_format="KPFITS", ID=""):
+    # TODO: Add warning about input format and switch to KPFITS in future version?
+    def __init__(self, fname=None, array=None, ndgt=5, bmax=None, hexa=False, input_format="LEGACY", ID=""):
         ''' Default instantiation of a KerPhase_Relation object:
 
         -------------------------------------------------------------------

--- a/xara/kpo.py
+++ b/xara/kpo.py
@@ -700,9 +700,12 @@ class KPO():
         hdul += [detpa_hdu]
 
         # Complex visibility data
-        # TODO: This has an extra first dim compared to standard in K22
-        cvis_arr = np.array(self.CVIS)
-        cvis_arr = np.stack([cvis_arr.real, cvis_arr.imag], axis=1)
+        # Concatenate all extracted frames along axis 0 (Nf, Nbl)
+        cvis_arr = np.concatenate(self.CVIS)
+        # Split real and imag along axis 0 (2, Nframes, Nbl)
+        cvis_arr = np.stack([cvis_arr.real, cvis_arr.imag], axis=0)
+        # Add wavelength dimension (2, Nf, 1, Nbl)
+        cvis_arr = np.expand_dims(cvis_arr, axis=2)
         cvis_data_hdu = fits.ImageHDU(cvis_arr)
         cvis_data_hdu.name = 'CVIS-DATA'
         hdul += [cvis_data_hdu]

--- a/xara/kpo.py
+++ b/xara/kpo.py
@@ -52,7 +52,7 @@ class KPO():
         ------------------------------------------------------------------- '''
 
     # TODO: Add warning about input format and switch to KPFITS in future version?
-    def __init__(self, fname=None, array=None, ndgt=5, bmax=None, hexa=False, input_format="LEGACY", ID=""):
+    def __init__(self, fname=None, array=None, ndgt=5, bmax=None, hexa=False, input_format="LEGACY", ID="", kpi_model=None):
         ''' Default instantiation of a KerPhase_Relation object:
 
         -------------------------------------------------------------------
@@ -61,8 +61,15 @@ class KPO():
         -------------------------------------------------------------------'''
 
         # Default instantiation.
-        self.kpi = kpi.KPI(fname=fname, array=array,
-                           ndgt=ndgt, bmax=bmax, hexa=hexa, ID=ID)
+        if kpi_model is not None:
+            self.kpi = copy.deepcopy(kpi_model)
+            self.kpi.rebuild_model(ndgt=ndgt, bmax=bmax, hexa=hexa)
+            if fname is not None or array is not None:
+                warnings.warn("kpi_model was provided. Ignoring fname and array argument.", RuntimeWarning)
+        else:
+            self.kpi = kpi.KPI(fname=fname, array=array,
+                            ndgt=ndgt, bmax=bmax, hexa=hexa, ID=ID)
+
 
         self.TARGET = []  # source names
         self.CVIS = []    # complex visibilities
@@ -251,7 +258,7 @@ class KPO():
             res = self.__extract_cvis_fft(image, m2pix)
         else:
             res = None
-            print("Requested method %s does not exist" % (method,))
+            raise ValueError("Requested method %s does not exist" % (method,))
         self.M2PIX = m2pix  # to check the validity of aux data next time !
         return res
 
@@ -975,7 +982,7 @@ class KPO():
         ---------------------------------------------------------------- '''
 
         try:
-            _ = self.TARGET[index]
+            _ = self.KPDT[index]
         except IndexError:
             print("Requested dataset (index=%d) does not exist" % (index,))
             print("No data-matching binary model can be built.")

--- a/xara/kpo.py
+++ b/xara/kpo.py
@@ -651,7 +651,7 @@ class KPO():
         blm_hdu = kpi_fits['BLM-MAT']
         hdul += [blm_hdu]
 
-        # Kenrel phase data
+        # Kernel phase data
         # Supports only single object
         kpdt_arr = np.concatenate(self.KPDT)
         if len(self.KPDT) > 1:

--- a/xara/kpo.py
+++ b/xara/kpo.py
@@ -651,8 +651,16 @@ class KPO():
 
         # Kenrel phase data
         # Supports only single object
-        kpdt_arr = np.array(self.KPDT)
-        # TODO: This has an extra first dim compared to standard in K22
+        kpdt_arr = np.concatenate(self.KPDT)
+        if len(self.KPDT) > 1:
+            warnings.warn(
+                "Saving all extracted frames and cubges in a single KPFITS file"
+                " along the 'frame' dimension."
+                " Use separate KPO objects if you want something else.",
+                stacklevel=2,
+            )
+        # Add wavelength axis as specified in K22
+        kpdt_arr = np.expand_dims(kpdt_arr, axis=1)
         kpdata_hdu = fits.ImageHDU(kpdt_arr)
         kpdata_hdu.name = 'KP-DATA'
         hdul += [kpdata_hdu]

--- a/xara/try_nicmos.py
+++ b/xara/try_nicmos.py
@@ -5,9 +5,6 @@ import xara
 import numpy as np
 import matplotlib.pyplot as plt
 
-plt.ion()
-plt.show()
-
 ''' ------------------------------------------------------------------
     For this demonstration, two HST data sets on the same target at two
     different wavelengths (110W and 170M) are provided as part of this


### PR DESCRIPTION
This enables xara to load data from a KPFITS file and to save results to KPFITS. The format used follows @kammerje et al. 2023 (https://ui.adsabs.harvard.edu/abs/2023PASP..135a4502K/).

There are two things left as **TODO** in the code which should be addressed before merging:
- [x] What should we do with the list/datasets dimension in Xara when saving a result to KPFITS? Do multiple KPFITS files, all merge in a single one? I'd be in favor of collapsing this dimension I think, with a warning to say "we're collapsing the dataset dimension, this might not be what you expected".
- [x] What should be the default format when loading data now, the `"LEGACY"` FITS format or `"KPFITS"`? I put KPFITS but was not sure about that, should we set default to `None` and try both by default?

Fixes #20.

I think this is the last change I had locally, I'll work on merging this fork with the main one once this is merged.
